### PR TITLE
Adding Tal Garfinkel as a recognized contributor

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -34,6 +34,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * Foltzer, Adam ([@acfoltzer](https://github.com/acfoltzer))
 * Freyler, Robin ([@robbepop](https://github.com/robbepop))
 * Galli, Enrico ([@egalli](https://github.com/egalli))
+* Garfinkel, Tal ([@talg](https://github.com/talg))
 * Gohman, Dan ([@sunfishcode](https://github.com/sunfishcode))
 * Goldenring, Kate ([@kate-goldenring](https://github.com/kate-goldenring))
 * Hardock, Brian ([@fibonacci1729](https://github.com/fibonacci1729))


### PR DESCRIPTION
I'm self-nominating a recognized contributor.

Name: Tal Garfinkel
GitHub Username: @talg

Nomination:

I am self-nominating because of my past and ongoing contributions to the community including my work with the RLBox project and work on promoting Wasm for library sandboxing, work on improving hardware support for Wasm (HFI), as well as improve supporting for Wasm on existing hardware (segue,colorguard), and work on improving the state of SIMD support (co-championing flexible vector support). 


I have read and understood the qualifications for a Recognized Contributor.